### PR TITLE
WASI: fix path_open

### DIFF
--- a/src/modules/wasi/x86-64-linux/WspOneModule-x86-64-linux.v3
+++ b/src/modules/wasi/x86-64-linux/WspOneModule-x86-64-linux.v3
@@ -178,8 +178,8 @@ class X86_64Linux_WspOneModule extends WspOneModule {
 		var t = Linux.syscall(SYS_openat, (dir_fd.sysfd, Pointer.atContents(pathz.result), sysflags, 0x1B6));
 		var result_fd = t.0;
 		if (result_fd < 0) return i(mapErrno(result_fd));
-		DataWriters.write_range_u32(fdregion.result, u32.!(result_fd));
 		var wasi_fd = fdmap.alloc();
+		DataWriters.write_range_u32(fdregion.result, u32.!(wasi_fd));
 		fdmap.set(wasi_fd, WasiFd.new(int.view(result_fd), wasi_filetype.CHARACTER_DEVICE, false, Ranges.dup(pathz.result)));
 		return SUCCESS;
 	}


### PR DESCRIPTION
The Unix file descriptor was returned instead of the user-level file descriptor.